### PR TITLE
Switch to 'openshift/jenkins-1-centos7:latest' docker image

### DIFF
--- a/services/openshift/templates/adb/jenkins-ephemeral-next-template.json
+++ b/services/openshift/templates/adb/jenkins-ephemeral-next-template.json
@@ -64,7 +64,7 @@
             "containers": [
               {
                 "name": "jenkins",
-                "image": "docker.io/openshift/jenkins-1-centos7:dev",
+                "image": "docker.io/openshift/jenkins-1-centos7:latest",
                 "readinessProbe": {
                   "timeoutSeconds": 3,
                   "initialDelaySeconds": 3,


### PR DESCRIPTION
the ':dev' one is dead.
